### PR TITLE
Add 2.4.6 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,5 @@ services:
         tty: true
         volumes:
             - "~/.composer/cache:/root/.composer/cache"
+            - "~/.composer/auth.json:/root/.composer/auth.json"
         env_file: .env

--- a/pipe.sh
+++ b/pipe.sh
@@ -10,7 +10,7 @@ DATABASE_ROOTPASSWORD=${DATABASE_ROOTPASSWORD:="rootpassword"}
 DATABASE_PASSWORD=${DATABASE_PASSWORD:="password"}
 
 # Service defaults
-ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST:="host.docker.internal"}
+OPENSEARCH_HOST=${OPENSEARCH_HOST:="host.docker.internal"}
 RABBITMQ_HOST=${RABBITMQ_HOST:="host.docker.internal"}
 DATABASE_HOST=${DATABASE_HOST:="host.docker.internal"}
 
@@ -53,15 +53,15 @@ run_integration_tests () {
   sed -i "s/'db-host' => 'localhost'/'db-host' => '$DATABASE_HOST'/" etc/install-config-mysql.php.dist
   sed -i "s/'db-user' => 'root'/'db-user' => '$DATABASE_USERNAME'/" etc/install-config-mysql.php.dist
   sed -i "s/'db-password' => '123123q'/'db-password' => '$DATABASE_PASSWORD'/" etc/install-config-mysql.php.dist
-  sed -i "s/'elasticsearch-host' => 'localhost'/'elasticsearch-host' => '$ELASTICSEARCH_HOST'/" etc/install-config-mysql.php.dist
+  sed -i "s/'opensearch-host' => 'localhost'/'opensearch-host' => '$OPENSEARCH_HOST'/" etc/install-config-mysql.php.dist
   sed -i "s/'amqp-host' => 'localhost'/'amqp-host' => '$RABBITMQ_HOST'/" etc/install-config-mysql.php.dist
 
   # Add extra configuration not available in enterprise edition
   sed -i "/^];/i 'consumers-wait-for-messages' => '0'," etc/install-config-mysql.php.dist
-  sed -i "/^];/i 'search-engine' => 'elasticsearch7'," etc/install-config-mysql.php.dist
-  sed -i "/^];/i 'elasticsearch-host' => '$ELASTICSEARCH_HOST'," etc/install-config-mysql.php.dist
-  sed -i "/^];/i 'elasticsearch-port' => 9200," etc/install-config-mysql.php.dist
-  sed -i "/^];/i 'elasticsearch-index-prefix' => 'magento_integration'," etc/install-config-mysql.php.dist
+  sed -i "/^];/i 'search-engine' => 'opensearch'," etc/install-config-mysql.php.dist
+  sed -i "/^];/i 'opensearch-host' => '$OPENSEARCH_HOST'," etc/install-config-mysql.php.dist
+  sed -i "/^];/i 'opensearch-port' => 9200," etc/install-config-mysql.php.dist
+  sed -i "/^];/i 'opensearch-index-prefix' => 'magento_integration'," etc/install-config-mysql.php.dist
   cat etc/install-config-mysql.php.dist
 
   php ../../../vendor/bin/phpunit $GROUP $TESTS_PATH
@@ -81,12 +81,14 @@ run_rest_api_tests () {
   sed -i 's/value="admin"/value="Test Webservice User"/' phpunit_rest.xml
   sed -i 's/value="123123q"/value="Test Webservice API key"/' phpunit_rest.xml
 
+  cat config/install-config-mysql.php.dist
   sed -i "s,http://localhost/,http://127.0.0.1:8082/index.php/," config/install-config-mysql.php
   sed -i "s/'db-host'                      => 'localhost'/'db-host' => '$DATABASE_HOST'/" config/install-config-mysql.php
   sed -i "s/'db-user'                      => 'root'/'db-user' => '$DATABASE_USERNAME'/" config/install-config-mysql.php
   sed -i "s/'db-password'                  => ''/'db-password' => '$DATABASE_PASSWORD'/" config/install-config-mysql.php
-  sed -i "s/'elasticsearch-host'           => 'localhost'/'elasticsearch-host' => '$ELASTICSEARCH_HOST'/" config/install-config-mysql.php
-  sed -i "/^];/i 'elasticsearch-index-prefix' => 'magento_rest'," config/install-config-mysql.php
+  sed -i "s/'opensearch-host'           => 'localhost'/'opensearch-host' => '$OPENSEARCH_HOST'/" config/install-config-mysql.php
+  sed -i "/^];/i 'opensearch-index-prefix' => 'magento_rest'," config/install-config-mysql.php
+  cat config/install-config-mysql.php
 
   cd ../../../
   php -S 127.0.0.1:8082 -t ./pub/ ./phpserver/router.php &
@@ -110,13 +112,15 @@ run_graphql_tests () {
   sed -i 's/value="123123q"/value="Test Webservice API key"/' phpunit_graphql.xml
   sed -i 's,value="config/install-config-mysql.php",value="config/install-config-mysql-graphql.php",' phpunit_graphql.xml
 
+  cat config/install-config-mysql.php.dist
   sed -i "s,http://localhost/,http://127.0.0.1:8083/index.php/," config/install-config-mysql-graphql.php
   sed -i "s/'db-host'                      => 'localhost'/'db-host' => '$DATABASE_HOST'/" config/install-config-mysql-graphql.php
   sed -i "s/'db-name'                      => 'magento_functional_tests'/'db-name' => 'magento_graphql_tests'/" config/install-config-mysql-graphql.php
   sed -i "s/'db-user'                      => 'root'/'db-user' => '$DATABASE_USERNAME'/" config/install-config-mysql-graphql.php
   sed -i "s/'db-password'                  => ''/'db-password' => '$DATABASE_PASSWORD'/" config/install-config-mysql-graphql.php
-  sed -i "s/'elasticsearch-host'           => 'localhost'/'elasticsearch-host' => '$ELASTICSEARCH_HOST'/" config/install-config-mysql-graphql.php
-  sed -i "/^];/i 'elasticsearch-index-prefix' => 'magento_graphql'," config/install-config-mysql-graphql.php
+  sed -i "s/'opensearch-host'           => 'localhost'/'opensearch-host' => '$OPENSEARCH_HOST'/" config/install-config-mysql-graphql.php
+  sed -i "/^];/i 'opensearch-index-prefix' => 'magento_graphql'," config/install-config-mysql-graphql.php
+  cat config/install-config-mysql.php
 
   cd ../../../
   php -S 127.0.0.1:8083 -t ./pub/ ./phpserver/router.php &

--- a/pipe.sh
+++ b/pipe.sh
@@ -120,7 +120,7 @@ run_graphql_tests () {
   sed -i "s/'db-password'                  => ''/'db-password' => '$DATABASE_PASSWORD'/" config/install-config-mysql-graphql.php
   sed -i "s/'opensearch-host'           => 'localhost'/'opensearch-host' => '$OPENSEARCH_HOST'/" config/install-config-mysql-graphql.php
   sed -i "/^];/i 'opensearch-index-prefix' => 'magento_graphql'," config/install-config-mysql-graphql.php
-  cat config/install-config-mysql.php
+  cat config/install-config-mysql-graphql.php
 
   cd ../../../
   php -S 127.0.0.1:8083 -t ./pub/ ./phpserver/router.php &

--- a/pipe.sh
+++ b/pipe.sh
@@ -15,7 +15,7 @@ RABBITMQ_HOST=${RABBITMQ_HOST:="host.docker.internal"}
 DATABASE_HOST=${DATABASE_HOST:="host.docker.internal"}
 
 REPOSITORY_URL=${REPOSITORY_URL:="https://repo.magento.com/"}
-MAGENTO_VERSION=${MAGENTO_VERSION:="magento/project-community-edition:>=2.4.5 <2.4.6"}
+MAGENTO_VERSION=${MAGENTO_VERSION:="magento/project-community-edition:>=2.4.6 <2.4.7"}
 
 GROUP=${GROUP:=""}
 TESTS_PATH=${TESTS_PATH:=""}

--- a/pipe.sh
+++ b/pipe.sh
@@ -10,7 +10,7 @@ DATABASE_ROOTPASSWORD=${DATABASE_ROOTPASSWORD:="rootpassword"}
 DATABASE_PASSWORD=${DATABASE_PASSWORD:="password"}
 
 # Service defaults
-OPENSEARCH_HOST=${OPENSEARCH_HOST:="host.docker.internal"}
+ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST:="host.docker.internal"}
 RABBITMQ_HOST=${RABBITMQ_HOST:="host.docker.internal"}
 DATABASE_HOST=${DATABASE_HOST:="host.docker.internal"}
 
@@ -34,8 +34,11 @@ composer_setup () {
       echo "composer.lock does not exist."
       composer create-project --repository-url="$REPOSITORY_URL" "$MAGENTO_VERSION" /magento2 --no-install
       cd /magento2
+
+    if [[ ! -z "${COMPOSER_PACKAGES}" ]]; then
       composer config repositories.local path $BITBUCKET_CLONE_DIR
       composer require $COMPOSER_PACKAGES "@dev" --no-update
+    fi
   fi
 
   composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
@@ -50,18 +53,24 @@ run_integration_tests () {
 
   cd dev/tests/integration
   cat etc/install-config-mysql.php.dist
+
+  # Replace Opensearch with Elasticsearch
+  sed -i "s/'search-engine'\s*=>\s*'opensearch'/'search-engine' => 'elasticsearch7'/" etc/install-config-mysql.php.dist
+  sed -i "s/'opensearch-host'/'elasticsearch-host'/" etc/install-config-mysql.php.dist
+  sed -i "s/'opensearch-port'/'elasticsearch-port'/" etc/install-config-mysql.php.dist
+
   sed -i "s/'db-host' => 'localhost'/'db-host' => '$DATABASE_HOST'/" etc/install-config-mysql.php.dist
   sed -i "s/'db-user' => 'root'/'db-user' => '$DATABASE_USERNAME'/" etc/install-config-mysql.php.dist
   sed -i "s/'db-password' => '123123q'/'db-password' => '$DATABASE_PASSWORD'/" etc/install-config-mysql.php.dist
-  sed -i "s/'opensearch-host' => 'localhost'/'opensearch-host' => '$OPENSEARCH_HOST'/" etc/install-config-mysql.php.dist
+  sed -i "s/'elasticsearch-host' => 'localhost'/'elasticsearch-host' => '$ELASTICSEARCH_HOST'/" etc/install-config-mysql.php.dist
   sed -i "s/'amqp-host' => 'localhost'/'amqp-host' => '$RABBITMQ_HOST'/" etc/install-config-mysql.php.dist
 
   # Add extra configuration not available in enterprise edition
   sed -i "/^];/i 'consumers-wait-for-messages' => '0'," etc/install-config-mysql.php.dist
-  sed -i "/^];/i 'search-engine' => 'opensearch'," etc/install-config-mysql.php.dist
-  sed -i "/^];/i 'opensearch-host' => '$OPENSEARCH_HOST'," etc/install-config-mysql.php.dist
-  sed -i "/^];/i 'opensearch-port' => 9200," etc/install-config-mysql.php.dist
-  sed -i "/^];/i 'opensearch-index-prefix' => 'magento_integration'," etc/install-config-mysql.php.dist
+  sed -i "/^];/i 'search-engine' => 'elasticsearch7'," etc/install-config-mysql.php.dist
+  sed -i "/^];/i 'elasticsearch-host' => '$ELASTICSEARCH_HOST'," etc/install-config-mysql.php.dist
+  sed -i "/^];/i 'elasticsearch-port' => 9200," etc/install-config-mysql.php.dist
+  sed -i "/^];/i 'elasticsearch-index-prefix' => 'magento_integration'," etc/install-config-mysql.php.dist
   cat etc/install-config-mysql.php.dist
 
   php ../../../vendor/bin/phpunit $GROUP $TESTS_PATH
@@ -76,18 +85,25 @@ run_rest_api_tests () {
   cd dev/tests/api-functional
   cp phpunit_rest.xml.dist phpunit_rest.xml
   cp config/install-config-mysql.php.dist config/install-config-mysql.php
+
   sed -i 's/name="TESTS_MAGENTO_INSTALLATION" value="disabled"/name="TESTS_MAGENTO_INSTALLATION" value="enabled"/' phpunit_rest.xml
   sed -i 's#http://magento.url#http://127.0.0.1:8082/index.php/#' phpunit_rest.xml
   sed -i 's/value="admin"/value="Test Webservice User"/' phpunit_rest.xml
   sed -i 's/value="123123q"/value="Test Webservice API key"/' phpunit_rest.xml
 
   cat config/install-config-mysql.php.dist
+
+  # Replace Opensearch with Elasticsearch
+  sed -i "s/'search-engine'\s*=>\s*'opensearch'/'search-engine' => 'elasticsearch7'/" config/install-config-mysql.php
+  sed -i "s/'opensearch-host'/'elasticsearch-host'/" config/install-config-mysql.php
+  sed -i "s/'opensearch-port'/'elasticsearch-port'/" config/install-config-mysql.php
+
   sed -i "s,http://localhost/,http://127.0.0.1:8082/index.php/," config/install-config-mysql.php
-  sed -i "s/'db-host'                      => 'localhost'/'db-host' => '$DATABASE_HOST'/" config/install-config-mysql.php
-  sed -i "s/'db-user'                      => 'root'/'db-user' => '$DATABASE_USERNAME'/" config/install-config-mysql.php
-  sed -i "s/'db-password'                  => ''/'db-password' => '$DATABASE_PASSWORD'/" config/install-config-mysql.php
-  sed -i "s/'opensearch-host'           => 'localhost'/'opensearch-host' => '$OPENSEARCH_HOST'/" config/install-config-mysql.php
-  sed -i "/^];/i 'opensearch-index-prefix' => 'magento_rest'," config/install-config-mysql.php
+  sed -i "s/'db-host'\s*=> 'localhost'/'db-host' => '$DATABASE_HOST'/" config/install-config-mysql.php
+  sed -i "s/'db-user'\s*=> 'root'/'db-user' => '$DATABASE_USERNAME'/" config/install-config-mysql.php
+  sed -i "s/'db-password'\s*=> ''/'db-password' => '$DATABASE_PASSWORD'/" config/install-config-mysql.php
+  sed -i "s/'elasticsearch-host'\s*=>\s*'localhost'/'elasticsearch-host' => '$ELASTICSEARCH_HOST'/" config/install-config-mysql.php
+  sed -i "/^];/i 'elasticsearch-index-prefix' => 'magento_rest'," config/install-config-mysql.php
   cat config/install-config-mysql.php
 
   cd ../../../
@@ -106,6 +122,7 @@ run_graphql_tests () {
 
   cp phpunit_graphql.xml.dist phpunit_graphql.xml
   cp config/install-config-mysql.php.dist config/install-config-mysql-graphql.php
+
   sed -i 's/name="TESTS_MAGENTO_INSTALLATION" value="disabled"/name="TESTS_MAGENTO_INSTALLATION" value="enabled"/' phpunit_graphql.xml
   sed -i 's#http://magento.url#http://127.0.0.1:8083/index.php/#' phpunit_graphql.xml
   sed -i 's/value="admin"/value="Test Webservice User"/' phpunit_graphql.xml
@@ -113,13 +130,19 @@ run_graphql_tests () {
   sed -i 's,value="config/install-config-mysql.php",value="config/install-config-mysql-graphql.php",' phpunit_graphql.xml
 
   cat config/install-config-mysql.php.dist
+
+  # Replace Opensearch with Elasticsearch
+  sed -i "s/'search-engine'\s*=>\s*'opensearch'/'search-engine' => 'elasticsearch7'/" config/install-config-mysql-graphql.php
+  sed -i "s/'opensearch-host'/'elasticsearch-host'/" config/install-config-mysql-graphql.php
+  sed -i "s/'opensearch-port'/'elasticsearch-port'/" config/install-config-mysql-graphql.php
+
   sed -i "s,http://localhost/,http://127.0.0.1:8083/index.php/," config/install-config-mysql-graphql.php
-  sed -i "s/'db-host'                      => 'localhost'/'db-host' => '$DATABASE_HOST'/" config/install-config-mysql-graphql.php
-  sed -i "s/'db-name'                      => 'magento_functional_tests'/'db-name' => 'magento_graphql_tests'/" config/install-config-mysql-graphql.php
-  sed -i "s/'db-user'                      => 'root'/'db-user' => '$DATABASE_USERNAME'/" config/install-config-mysql-graphql.php
-  sed -i "s/'db-password'                  => ''/'db-password' => '$DATABASE_PASSWORD'/" config/install-config-mysql-graphql.php
-  sed -i "s/'opensearch-host'           => 'localhost'/'opensearch-host' => '$OPENSEARCH_HOST'/" config/install-config-mysql-graphql.php
-  sed -i "/^];/i 'opensearch-index-prefix' => 'magento_graphql'," config/install-config-mysql-graphql.php
+  sed -i "s/'db-host'\s*=> 'localhost'/'db-host' => '$DATABASE_HOST'/" config/install-config-mysql-graphql.php
+  sed -i "s/'db-name'\s*=> 'magento_functional_tests'/'db-name' => 'magento_graphql_tests'/" config/install-config-mysql-graphql.php
+  sed -i "s/'db-user'\s*=> 'root'/'db-user' => '$DATABASE_USERNAME'/" config/install-config-mysql-graphql.php
+  sed -i "s/'db-password'\s*=> ''/'db-password' => '$DATABASE_PASSWORD'/" config/install-config-mysql-graphql.php
+  sed -i "s/'elasticsearch-host'\s*=> 'localhost'/'elasticsearch-host' => '$ELASTICSEARCH_HOST'/" config/install-config-mysql-graphql.php
+  sed -i "/^];/i 'elasticsearch-index-prefix' => 'magento_graphql'," config/install-config-mysql-graphql.php
   cat config/install-config-mysql-graphql.php
 
   cd ../../../


### PR DESCRIPTION
2.4.6 attempts to switch to opensearch in the configuration templates. Until Opensearch docker images allow us to configure environment variable using snake prefix, we will fallback to using Elasticsearch.

See https://github.com/opensearch-project/docker-images/issues/20
