### PR TITLE
Merge repositories object from module's composer.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:8.1-alpine
+FROM php:8.2-alpine
 
-RUN apk add mariadb-client procps git --no-cache
+RUN apk add mariadb-client procps git jq --no-cache
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ a new magento project.
 | `DATABASE_HOST`         | Must be `host.docker.internal` when running in pipelines. Optionally change this if you are developing the pipe locally.                                   |
 | `COMPOSER_AUTH`         | JSON stringified composer `auth.json` with the relevant configuration you need.                                                                            |
 | `REPOSITORY_URL`        | `https://repo.magento.com/` - If using this, make sure the `COMPOSER_AUTH` variable is set. <br>  `https://mirror.mage-os.org/` - Only supports open source edition. <br> Default: `https://repo.magento.com/` |
-| `MAGENTO_VERSION`       | (Optional) Default: `magento/project-community-edition:>=2.4.5 <2.4.6` <br> Commerce: `magento/project-enterprise-edition:>=2.4.5 <2.4.6`                                                                                  |
+| `MAGENTO_VERSION`       | (Optional) Default: `magento/project-community-edition:>=2.4.6 <2.4.7` <br> Commerce: `magento/project-enterprise-edition:>=2.4.6 <2.4.7`                                                                                  |
 | `GROUP`                 | (Optional) Specify test group(s) to run. Example: `--group inventory,indexer_dimension` <br> See phpunit [@group annotation](https://phpunit.readthedocs.io/en/9.5/annotations.html#group)                                                                    |
 | `TESTS_PATH`            | (Optional) Specify a test path to run. Example `./app/code/The/Module`                                                                                     |
 
 ## Example Pipeline
 ```yml
-image: php:8.1
+image: php:8.2
 
 definitions:
   services:
@@ -41,7 +41,7 @@ definitions:
         ES_JAVA_OPTS: '-Xms512m -Xmx512m'
 
     mariadb:
-      image: mariadb:10.4
+      image: mariadb:10.6
       memory: 256
       variables:
         MYSQL_DATABASE: magento_integration_tests
@@ -50,7 +50,7 @@ definitions:
         MYSQL_ROOT_PASSWORD: rootpassword
 
     rabbitmq:
-      image: rabbitmq:3.9-management
+      image: rabbitmq:3.11-management
       memory: 256
       env:
         RABBITMQ_DEFAULT_USER: guest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,14 @@ services:
             ES_SETTING_DISCOVERY_TYPE: single-node
             ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     mariadb:
-        image: mariadb:10.4
+        image: mariadb:10.6
         environment:
             MYSQL_DATABASE: magento_integration_tests
             MYSQL_USER: user
             MYSQL_PASSWORD: password
             MYSQL_ROOT_PASSWORD: rootpassword
     rabbitmq:
-        image: rabbitmq:3.9-management
+        image: rabbitmq:3.11-management
         environment:
             RABBITMQ_DEFAULT_USER: guest
             RABBITMQ_DEFAULT_PASS: guest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
             RABBITMQ_DEFAULT_PASS: guest
     magento:
         build: .
-        entrypoint: /bin/ash
+        entrypoint: /bin/sh
         tty: true
         volumes:
             - "~/.composer/cache:/root/.composer/cache"

--- a/pipe.sh
+++ b/pipe.sh
@@ -37,7 +37,7 @@ composer_setup () {
 
     if [[ ! -z "${COMPOSER_PACKAGES}" ]]; then
       # Merge the repository object from module's composer.json into magento's composer.json
-      jq --slurpfile app $BITBUCKET_CLONE_DIR/composer.json '.repositories += [$app[0].repositories[]]' composer.json \
+      jq --slurpfile app $BITBUCKET_CLONE_DIR/composer.json '.repositories += [$app[0].repositories[]?]' composer.json \
       > merged.composer.json
 
       jq --arg path $BITBUCKET_CLONE_DIR '.repositories += [{ type: "path", "url": $path}]' merged.composer.json > composer.json

--- a/pipe.sh
+++ b/pipe.sh
@@ -36,7 +36,12 @@ composer_setup () {
       cd /magento2
 
     if [[ ! -z "${COMPOSER_PACKAGES}" ]]; then
-      composer config repositories.local path $BITBUCKET_CLONE_DIR
+      # Merge the repository object from module's composer.json into magento's composer.json
+      jq --slurpfile app $BITBUCKET_CLONE_DIR/composer.json '.repositories += [$app[0].repositories[]]' composer.json \
+      > merged.composer.json
+
+      jq --arg path $BITBUCKET_CLONE_DIR '.repositories += [{ type: "path", "url": $path}]' merged.composer.json > composer.json
+
       composer require $COMPOSER_PACKAGES "@dev" --no-update
     fi
   fi


### PR DESCRIPTION
When using this pipe to test standalone modules there is no way to add repositories to the implicitly created magento's `composer.json`. This is a problem when the module to be tested has dependencies which are not available publicly.

Minor maintenance work and update readme.