### PR TITLE
Ensure local repository has priority, and declare specific version to…

### DIFF
--- a/pipe.sh
+++ b/pipe.sh
@@ -37,12 +37,15 @@ composer_setup () {
 
     if [[ ! -z "${COMPOSER_PACKAGES}" ]]; then
       # Merge the repository object from module's composer.json into magento's composer.json
-      jq --slurpfile app $BITBUCKET_CLONE_DIR/composer.json '.repositories += [$app[0].repositories[]?]' composer.json \
-      > merged.composer.json
+      jq --arg package $COMPOSER_PACKAGES --arg path $BITBUCKET_CLONE_DIR \
+      '.repositories += [{ "type": "path", "url": $path, "options": { "versions": { ($package): "99-dev" }}}]' \
+      composer.json > merged.composer.json
 
-      jq --arg path $BITBUCKET_CLONE_DIR '.repositories += [{ type: "path", "url": $path}]' merged.composer.json > composer.json
+      jq --slurpfile app $BITBUCKET_CLONE_DIR/composer.json '.repositories += [$app[0].repositories[]?]' \
+      merged.composer.json > composer.json
 
-      composer require $COMPOSER_PACKAGES "@dev" --no-update
+
+      composer require $COMPOSER_PACKAGES "99-dev" --no-update
     fi
   fi
 


### PR DESCRIPTION
… avoid dependency issues

If a project's  `repositories` section in composer.json includes a repository that serves the module itself (e.g. a satis repository), then the module would be sourced from there.

This change does two things:
 - Puts the local path repository before any others (apart from the main Magento repository)
 - Declares a fake version for the local repository that is then used when requiring the package