### PR TITLE
feat: get php version from build tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:8.2-alpine
+ARG PHP_VERSION
+FROM php:${PHP_VERSION}-alpine
 
 RUN apk add mariadb-client procps git jq --no-cache
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --build-arg PHP_VERSION="$(echo $DOCKER_TAG | sed 's/-experimental//g')" -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
Get the PHP version from the build tag. This will let us support 8.2 and 8.3 plus any future versions of PHP.

`DO-1877: Code review`